### PR TITLE
Use pathlib to avoid ambiguities in how raw_path is split

### DIFF
--- a/bin/run_processing.py
+++ b/bin/run_processing.py
@@ -179,7 +179,7 @@ if __name__ == "__main__":
     pos_cont = input_data_dir_split[-1].find('continuous_')
     if pos_cont!=-1:
         series_dir = input_data_dir_split[-1][11:]
-        output_dir = str(Path(raw_path).joinpath('trigger_' + series_dir))
+        output_dir = str(Path(raw_path).parent.joinpath('trigger_' + series_dir))
            
     if not os.path.isdir(output_dir):
         try:

--- a/bin/run_processing.py
+++ b/bin/run_processing.py
@@ -4,6 +4,7 @@ import os
 import time
 from datetime import datetime
 from glob import glob
+from pathlib import Path
 from pytesdaq.processing.trigger import ContinuousData
 import pytesdaq.config.settings as settings
 from pytesdaq.utils import arg_utils
@@ -130,7 +131,7 @@ if __name__ == "__main__":
     # input path
     # ------------------
     input_data_dir = raw_path
-    input_data_dir_split = input_data_dir.split('/')
+    input_data_dir_split = Path(raw_path).parts
     if series is not None and input_data_dir_split[-1]!=series:
         input_data_dir_temp = input_data_dir + '/' + series
         if os.path.isdir(input_data_dir_temp):
@@ -178,7 +179,7 @@ if __name__ == "__main__":
     pos_cont = input_data_dir_split[-1].find('continuous_')
     if pos_cont!=-1:
         series_dir = input_data_dir_split[-1][11:]
-        output_dir = raw_path[0:-len(input_data_dir_split[-1])] + 'trigger_' + series_dir 
+        output_dir = str(Path(raw_path).joinpath('trigger_' + series_dir))
            
     if not os.path.isdir(output_dir):
         try:

--- a/bin/run_processing.py
+++ b/bin/run_processing.py
@@ -186,7 +186,7 @@ if __name__ == "__main__":
             os.makedirs(output_dir)
             os.chmod(output_dir, stat.S_IRWXG | stat.S_IRWXU | stat.S_IROTH | stat.S_IXOTH)
         except OSError:
-            print('\nERROR: Unable to create directory "'+ data_path  + '"!\n')
+            print('\nERROR: Unable to create directory "'+ output_dir  + '"!\n')
             exit()
             
 

--- a/bin/run_processing.py
+++ b/bin/run_processing.py
@@ -131,7 +131,7 @@ if __name__ == "__main__":
     # input path
     # ------------------
     input_data_dir = raw_path
-    input_data_dir_split = Path(raw_path).parts
+    input_data_dir_split = Path(input_data_dir).parts
     if series is not None and input_data_dir_split[-1]!=series:
         input_data_dir_temp = input_data_dir + '/' + series
         if os.path.isdir(input_data_dir_temp):
@@ -179,7 +179,7 @@ if __name__ == "__main__":
     pos_cont = input_data_dir_split[-1].find('continuous_')
     if pos_cont!=-1:
         series_dir = input_data_dir_split[-1][11:]
-        output_dir = str(Path(raw_path).parent.joinpath('trigger_' + series_dir))
+        output_dir = str(Path(input_data_dir).parent.joinpath('trigger_' + series_dir))
            
     if not os.path.isdir(output_dir):
         try:


### PR DESCRIPTION
In `bin/run_processing.py`, we have: https://github.com/berkeleytes/pytesdaq/blob/7acfbbb77117db6720e8ec70471ce3baf44ef109/bin/run_processing.py#L133 

We see that the `input_data_dir` is set based on a string split on `/`, taking the last value. However, when the `output_dir` is created, its location changes based on whether or not the inputted `raw_path` ended in a `/` or not. 

For example, if i run:
```python
python run_processing.py --raw_path /sdata/runs/run8/raw/continuous_20210628_1639 -s I2_D20210628_T194040 --trace_length_ms 52
```
The output directory is placed in `/sdata/runs/run8/raw/` . But if `--raw_path` is instead `/sdata/runs/run8/raw/continuous_20210628_1639/`, then the output directory is placed in `/sdata/runs/run8/raw/continuous_20210628_1639/`. The first one is the behavior we want. This PR contains my proposed solution.

We switch to using the `pathlib` library for dealing with these paths, such that there are no ambiguities in whether or not `raw_path`. Basically, the changes are simple:

- instead of splitting a path on `'/'`, we use the `Path.parts` property, which has the same behavior regardless of a trailing forward slash.
- switched the setting of `output_dir` to use `Path.parent` and `Path.joinpath` to create the needed path, which simplifies its creation and no longer relies on truncation of the path.